### PR TITLE
Don't allow duplicate `addNamespace()` calls

### DIFF
--- a/lib/compact.js
+++ b/lib/compact.js
@@ -38,16 +38,20 @@ module.exports.createCompact = function(options) {
       throw new Error('Invalid namespace');
     }
 
-    if (!namespaces[name]) {
-      var newNamespace = {};
-      Object.defineProperty(namespaces, name, {
-        get: function() { return newNamespace; },
-        configurable: false,
-        enumerable: true,
-        set: function(value) {
-          throw new Error('You can not alter a registered namespace \'' + name + '\''); }
-      });
+    if (namespaces[name]) {
+      throw new Error('The namespace \'' +
+        name + '\' has already been added');
     }
+
+
+    var newNamespace = {};
+    Object.defineProperty(namespaces, name, {
+      get: function() { return newNamespace; },
+      configurable: false,
+      enumerable: true,
+      set: function(value) {
+        throw new Error('You can not alter a registered namespace \'' + name + '\''); }
+    });
     var namespace = namespaces[name];
 
     function addJs(filePath) {

--- a/test/compact.test.js
+++ b/test/compact.test.js
@@ -122,6 +122,16 @@ describe('compact.js', function() {
           .addJs('b.js');
       });
     });
+
+    describe('#addNamespace()', function () {
+      it('should not allow a namespace to be added more than once', function () {
+        (function () {
+          compact.addNamespace('foo');
+          compact.addNamespace('foo');
+        }).should.throw('The namespace \'foo\' has already been added');
+      });
+    });
+
   });
 
   describe('#js()', function() {


### PR DESCRIPTION
If the same namespace is created in two different places their contents are merged.

This pull request makes `addNamespace()` throw if it is called twice with the same name. I think this is the ideal behaviour. If not, it should at least warn.
