### PR TITLE
Precedence issue

### DIFF
--- a/lib/compact.js
+++ b/lib/compact.js
@@ -69,7 +69,7 @@ module.exports.createCompact = function(options) {
       for (var i = 0; i < paths.length; i++) {
         if (path.existsSync(paths[i])) {
           jsPath = paths[i];
-          continue;
+          break;
         }
       }
 

--- a/test/assets-alt/a.js
+++ b/test/assets-alt/a.js
@@ -1,0 +1,1 @@
+console.log("hello from alt!")

--- a/test/compact.test.js
+++ b/test/compact.test.js
@@ -359,5 +359,30 @@ describe('compact.js', function() {
 
 
     });
+
+    it('should give higher precedence to the added srcPath', function (done) {
+
+      compact.addNamespace('alternative', altPath);
+      compact.ns.alternative.addJs('a.js');
+
+      var app = {
+        helpers: function (helper) {},
+        configure: function(fn) {
+          fn();
+        }
+      };
+
+      compact.js(['alternative'])({ app : app }, {}, function () {
+
+        var compacted = fs.readFileSync(destPath + '/alternative.js', 'utf8')
+          , raw = fs.readFileSync(altPath + '/a.js', 'utf8');
+
+        compacted.should.equal(raw);
+        done();
+
+      });
+
+    });
+
   });
 });


### PR DESCRIPTION
When adding a `srcPath` for a namespace, the lookup should prefer this path to the 'default' path.

If you have `a.js` in `srcPath` and `a.js` in an added `srcPath`, currently the first `a.js` is retrieved. It should be the other way around.

I think you meant to do this in your code, but you put `continue` instead of `break` within the loop, which meant it carried on searching even though a match was found.

I have added a test for this case.
