### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "should": "*",
+    "should": ">=0.6",
     "async": "~0.1",
     "asyncjs": "~0.0"
   }


### PR DESCRIPTION
Compact lists `should@*` as a dev dependency, but a feature `throwError` is used that was introduced in `should@0.6.1`. Not really a problem, but an easy fix for #20.
